### PR TITLE
Improve UI - rounds sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Application uses Auth0 for authentication. Set the following credentials
 
 ## Errors and Debugging
 ### "Failed to retrieve user session" 
-This is normally due to Auth0 having logged you in but the API doesn't recognise you (either due to a bug or out of sync data).
-To clear this, delete the relevant auth0 cookies in Chrome Settings: Privacy and Security > See all site data...
+This is normally due to Auth0 having logged you in but the API doesn't recognise you (either due to API not running, invalid API config, a bug or out of sync data).
+To clear this, ensure you are using the correct API, if it persists delete the relevant auth0 cookies in Chrome Settings: Privacy and Security > See all site data...
 
 
 ## Environments

--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,7 @@ body {
 .container-gutters {
   width: 92%;
   min-width: 13.75rem;
-  max-width: 100rem;
+  max-width: 75rem;
   margin: 0 auto;
 }
 

--- a/src/app/Clash/ClashHeader.js
+++ b/src/app/Clash/ClashHeader.js
@@ -116,7 +116,7 @@ class Clash extends Component {
                 alt="Tracks Icon"
                 src="https://res.cloudinary.com/soundclash/image/asset/vinyl-record-a40f320b60a2c98f4e4479f85ee1d218.svg"
                 width="20"
-              />
+              />&nbsp;
               <CountLabel label="Track" count={clash.tracks_count} />
             </span>
           </div>

--- a/src/app/Clash/CurrentRound/CurrentRound.js
+++ b/src/app/Clash/CurrentRound/CurrentRound.js
@@ -17,7 +17,7 @@ class CurrentRound extends Component {
     const state = ClashWorkflow.state(clash, currentUser);
 
     const props = { clash };
-    const previousTrack = clash.previous_track;
+    const ownerTrack = clash.owner_track;
 
     switch (state) {
       case ClashWorkflow.STATES.ReadyToAccept:
@@ -27,7 +27,7 @@ class CurrentRound extends Component {
       case ClashWorkflow.STATES.DisplayInfo:
         return (
           <PartialRound
-            previousTrack={previousTrack}
+            ownerTrack={ownerTrack}
             waitingForDescription={clash.waiting_for_description}
           />
         );

--- a/src/app/Clash/CurrentRound/PartialRound.js
+++ b/src/app/Clash/CurrentRound/PartialRound.js
@@ -2,22 +2,32 @@ import React from "react";
 import Track from "../Track/Track";
 
 const PartialRound = (props) => {
-  const previousTrack = props.previousTrack;
+  const ownerTrack = props.ownerTrack;
   const waitingForDescription = props.waitingForDescription;
 
   return (
     <div className="t-current-round container-fluid bg-grey px-0">
       <div className="row p-4 container-gutters">
-        <div className="col-sm-6 text-center p-3">
-          <Track track={previousTrack} />
-        </div>
-        <div className="t-clash-status col-sm-6 text-center p-3">
+        <div className="t-clash-status col-sm-6 order-1 order-sm-2 text-center p-3">
           <h2 className="text-truncate p-4 clash-item__header">Waiting...</h2>
           {waitingForDescription}
         </div>
+          <PreviousTrack {...{ownerTrack}} />
       </div>
     </div>
   );
 };
+
+const PreviousTrack=({ownerTrack})=>{
+  // We only need to show this track if it is the owner's track. If the last track was the opponents 
+  // it will show in the history as a completed round
+  if (!ownerTrack) return null
+
+  return(
+    <div className="col-sm-6 order-2 order-sm-1 text-center p-3">
+      <Track track={ownerTrack}/>
+    </div>
+  ) 
+}
 
 export default PartialRound;

--- a/src/app/Clash/CurrentRound/ReadyToAccept.js
+++ b/src/app/Clash/CurrentRound/ReadyToAccept.js
@@ -13,11 +13,11 @@ function ReadyToAccept({ currentClash, currentUser, jwt, dispatch }) {
     <div className="col-sm-12 text-center p-3">
       <div className="container-fluid bg-grey px-0">
         <div className="row p-4">
-          <div className="t-track-owner-container col-sm-6 text-center p-3">
+          <div className="t-track-owner-container col-sm-6 order-2 order-sm-1 text-center p-3">
             <Track track={owner_track} />
           </div>
-          <div className="t-track-opponent-container col-sm-6 text-center p-3">
-            <h2 className="text-truncate p-4 clash-item__header">
+          <div className="t-track-opponent-container col-sm-6 order-1 order-sm-2 text-center p-3">
+            <h2 className="text-truncate  p-4 clash-item__header">
               Waiting for you
             </h2>
             <div>

--- a/src/app/Clash/CurrentRound/Upload.js
+++ b/src/app/Clash/CurrentRound/Upload.js
@@ -5,6 +5,7 @@ import Loading from "../../shared/Loading";
 import { useAuth0 } from "@auth0/auth0-react";
 import ConnectedErrorAlert from "../../shared/ConnectedErrorAlert";
 import { actionContexts } from "../../../actions";
+import Track from "../Track/Track";
 
 const Upload = ({ clash, createTrack, clearError, apiError }) => {
   const { isAuthenticated, loginWithRedirect } = useAuth0();
@@ -50,69 +51,86 @@ const Upload = ({ clash, createTrack, clearError, apiError }) => {
 
   const previousTrack = clash.previous_track;
   const otherPlayer = clash.private_info.other_player;
+  const ownerTrack = clash.owner_track;
 
   return (
-    <div className="container-fluid current-round-intro">
-      <div
-        className="t-clash-status mx-auto text-center p-3"
-        style={{ maxWidth: "40.25rem" }}
-      >
-        <p>
-          <strong>{otherPlayer.name}</strong> just played{" "}
-          <em>{previousTrack.name}</em>
-        </p>
-        <p>
-          <strong>Now it's your turn...</strong>
-        </p>
+    <div className="container-fluid">
+      <div className="row">
+        <div className=" current-round-intro col-sm-12 text-center p-3">
+          <div
+            className="t-clash-status mx-auto text-center p-3"
+            style={{ maxWidth: "40.25rem" }}
+          >
+            <p>
+              <strong>{otherPlayer.name}</strong> just played{" "}
+              <em>{previousTrack.name}</em>
+            </p>
+            <p>
+              <strong>Now it's your turn...</strong>
+            </p>
 
-        <div style={{ maxWidth: "37.5rem" }}>
-          <form onSubmit={handleSubmit}>
-            <ConnectedErrorAlert actionContext={actionContexts.CREATE_TRACK} />
+            <div style={{ maxWidth: "37.5rem" }}>
+              <form onSubmit={handleSubmit}>
+                <ConnectedErrorAlert actionContext={actionContexts.CREATE_TRACK} />
 
-            <div className="row py-2 px-0 mx-0">
-              <YouTubeInput.Component
-                state={youTubeState}
-                setState={setYouTubeState}
-              />
-            </div>
+                <div className="row py-2 px-0 mx-0">
+                  <YouTubeInput.Component
+                    state={youTubeState}
+                    setState={setYouTubeState}
+                  />
+                </div>
 
-            <div className="row py-2 px-0 mx-0">
-              <div className="col text-left px-0 mx-0">
-                <textarea
-                  type="text"
-                  required
-                  value={commentText}
-                  className="form-control"
-                  name="commentText"
-                  placeholder="Say what you have to say"
-                  onChange={commentText_handleChange}
-                  style={{ background: "none" }}
-                />
-              </div>
+                <div className="row py-2 px-0 mx-0">
+                  <div className="col text-left px-0 mx-0">
+                    <textarea
+                      type="text"
+                      required
+                      value={commentText}
+                      className="form-control"
+                      name="commentText"
+                      placeholder="Say what you have to say"
+                      onChange={commentText_handleChange}
+                      style={{ background: "none" }}
+                    />
+                  </div>
+                </div>
+                <div className="py-0 px-0 mx-auto text-center ">
+                  <div className="px-0 ">
+                    <button
+                      className="btn btn-dark text-uppercase mr-3 t-btn-submit"
+                      type="submit"
+                    >
+                      <SpinnerButtonInner label="Submit" loading={loading} />
+                    </button>
+                    <button
+                      id="clearForm"
+                      className="btn btn-dark text-uppercase"
+                      type="button"
+                      onClick={clearState}
+                    >
+                      Clear
+                    </button>
+                  </div>
+                </div>
+              </form>
             </div>
-            <div className="py-0 px-0 mx-auto text-center ">
-              <div className="px-0 ">
-                <button
-                  className="btn btn-dark text-uppercase mr-3 t-btn-submit"
-                  type="submit"
-                >
-                  <SpinnerButtonInner label="Submit" loading={loading} />
-                </button>
-                <button
-                  id="clearForm"
-                  className="btn btn-dark text-uppercase"
-                  type="button"
-                  onClick={clearState}
-                >
-                  Clear
-                </button>
-              </div>
-            </div>
-          </form>
+          </div>
         </div>
+        <OwnerTrack {...{ownerTrack}} />
       </div>
     </div>
   );
 };
 
+const OwnerTrack=({ownerTrack})=>{
+  // We only need to show this track if it is the owner's track. If the last track was the opponents 
+  // it will show in the history as a completed round
+  if (!ownerTrack) return null
+
+  return(
+    <div className="col-sm-12 text-center p-3 container-gutters">
+      <Track track={ownerTrack}/>
+    </div>
+  ) 
+}
 export default Upload;

--- a/src/app/Clash/Round/Round.js
+++ b/src/app/Clash/Round/Round.js
@@ -7,10 +7,10 @@ function Round({ round }) {
   return (
     <div className="px-0">
       <div className={rowClassNames}>
-        <div className="t-track-owner col-sm-6 text-center p-3">
+        <div className="t-track-owner col-sm-6 order-2 order-sm-1 text-center p-3">
           <Track track={round.owner_track} />
         </div>
-        <div className="col-sm-6 text-center p-3">
+        <div className="col-sm-6 order-1 order-sm-2 text-center p-3">
           <Track track={round.opponent_track} />
         </div>
       </div>

--- a/src/app/Clash/Round/RoundCompressed.js
+++ b/src/app/Clash/Round/RoundCompressed.js
@@ -24,10 +24,10 @@ const RoundCompressed = ({ round, dispatch }) => {
         {round.comment_count}
       </strong>
       <h3 style={{ fontSize: "150%", fontWeight: "300" }}>
-        {round.owner_track_name}
+        {round.opponent_track_name}
       </h3>
       <h3 style={{ fontSize: "150%", fontWeight: "300" }}>
-        {round.opponent_track_name}
+        {round.owner_track_name}
       </h3>
     </a>
   );


### PR DESCRIPTION
General improvement of UI when viewing previous tracks

* Reverse order of tracks within rounds when presented in stacked mobile view
* Only show previous track in current round if it is the owners track to avoid duplicate track listings
* Reverse order of tracks for current round for mobile view